### PR TITLE
fix: :bug: declare organization in TFC variable set

### DIFF
--- a/doormat-prereqs/main.tf
+++ b/doormat-prereqs/main.tf
@@ -6,6 +6,10 @@ terraform {
   }
 }
 
+provider "aws" {
+  region = var.region
+}
+
 variable "tfc_organization" {
   type    = string
   default = ""
@@ -13,12 +17,12 @@ variable "tfc_organization" {
 
 variable "tfc_workspace_names" {
   type    = set(string)
-  default = ["1_networking", "5_nomad-cluster", "4_boundary-config", "6_nomad-nodes"]
+  default = ["1_networking", "5_nomad-cluster", "4_boundary-config", "6_nomad-nodes", "7_workload"]
 }
 
 resource "aws_iam_role" "doormat_role" {
   for_each = var.tfc_workspace_names
-  name = "tfc-doormat-role_${each.key}"
+  name     = "tfc-doormat-role_${each.key}"
   tags = {
     hc-service-uri = "app.terraform.io/${var.tfc_organization}/${each.key}"
   }
@@ -51,3 +55,4 @@ data "aws_iam_policy_document" "doormat_policy" {
     resources = ["*"]
   }
 }
+

--- a/doormat-prereqs/variables.tf
+++ b/doormat-prereqs/variables.tf
@@ -1,0 +1,4 @@
+variable "region" {
+  type    = string
+  default = "us-east-2"
+}

--- a/nomad-cluster/main.tf
+++ b/nomad-cluster/main.tf
@@ -10,6 +10,11 @@ terraform {
       version = "~> 5.8.0"
     }
 
+    packer = {
+      source = "hashicorp/packer"
+      version = "~> 0.83.0"
+    }
+
     vault = {
       source = "hashicorp/vault"
       version = "~> 3.18.0"

--- a/nomad-cluster/main.tf
+++ b/nomad-cluster/main.tf
@@ -10,8 +10,8 @@ terraform {
       version = "~> 5.8.0"
     }
 
-    packer = {
-      source = "hashicorp/packer"
+    hcp = {
+      source = "hashicorp/hcp"
       version = "~> 0.83.0"
     }
 

--- a/vault-auth-config/main.tf
+++ b/vault-auth-config/main.tf
@@ -90,9 +90,10 @@ resource "vault_jwt_auth_backend_role" "project_admin_role" {
 }
 
 resource "tfe_variable_set" "project_vault_auth" {
-  name        = "project_vault_auth_${data.tfe_project.project.name}"
-  description = "A set of example variables"
-  global      = false
+  name         = "project_vault_auth_${data.tfe_project.project.name}"
+  description  = "A set of example variables"
+  global       = false
+  organization = var.tfc_organization
 }
 
 resource "tfe_project_variable_set" "project_vault_auth" {

--- a/vault-auth-config/main.tf
+++ b/vault-auth-config/main.tf
@@ -1,17 +1,17 @@
 terraform {
   required_providers {
     boundary = {
-      source = "hashicorp/boundary"
+      source  = "hashicorp/boundary"
       version = "~> 1.1.9"
     }
 
     vault = {
-      source = "hashicorp/vault"
+      source  = "hashicorp/vault"
       version = "~> 3.18.0"
     }
 
     tfe = {
-        version = "~> 0.49.0"
+      version = "~> 0.49.0"
     }
   }
 }
@@ -57,8 +57,8 @@ resource "vault_policy" "admin" {
 }
 
 data "tfe_project" "project" {
-  name = "hashistack"
-  organization = "${var.tfc_organization}"
+  name         = "hashistack"
+  organization = var.tfc_organization
 }
 
 resource "vault_jwt_auth_backend" "tfc" {
@@ -103,57 +103,58 @@ resource "tfe_project_variable_set" "project_vault_auth" {
 
 // Create variables within the variable set
 resource "tfe_variable" "tfc_vault_provider_auth" {
-  key          = "TFC_VAULT_PROVIDER_AUTH"
-  value        = "true"
-  category     = "env"
+  key             = "TFC_VAULT_PROVIDER_AUTH"
+  value           = "true"
+  category        = "env"
   variable_set_id = tfe_variable_set.project_vault_auth.id
 }
 
 resource "tfe_variable" "tfc_vault_addr" {
-  key          = "TFC_VAULT_ADDR"
-  value        = data.terraform_remote_state.hcp_clusters.outputs.vault_public_endpoint
-  category     = "env"
+  key             = "TFC_VAULT_ADDR"
+  value           = data.terraform_remote_state.hcp_clusters.outputs.vault_public_endpoint
+  category        = "env"
   variable_set_id = tfe_variable_set.project_vault_auth.id
 }
 
 resource "tfe_variable" "tfc_vault_namespace" {
-  key          = "TFC_VAULT_NAMESPACE"
-  value        = "admin"
-  category     = "env"
+  key             = "TFC_VAULT_NAMESPACE"
+  value           = "admin"
+  category        = "env"
   variable_set_id = tfe_variable_set.project_vault_auth.id
 }
 
 resource "tfe_variable" "tfc_vault_run_role" {
-  key          = "TFC_VAULT_RUN_ROLE"
-  value        = vault_jwt_auth_backend_role.project_admin_role.role_name
-  category     = "env"
+  key             = "TFC_VAULT_RUN_ROLE"
+  value           = vault_jwt_auth_backend_role.project_admin_role.role_name
+  category        = "env"
   variable_set_id = tfe_variable_set.project_vault_auth.id
 }
 
 resource "tfe_variable" "tfc_vault_auth_path" {
-  key          = "TFC_VAULT_AUTH_PATH"
-  value        = vault_jwt_auth_backend.tfc.path
-  category     = "env"
+  key             = "TFC_VAULT_AUTH_PATH"
+  value           = vault_jwt_auth_backend.tfc.path
+  category        = "env"
   variable_set_id = tfe_variable_set.project_vault_auth.id
 }
 
 resource "tfe_variable" "vault_addr" {
-  key          = "VAULT_ADDR"
-  value        = data.terraform_remote_state.hcp_clusters.outputs.vault_public_endpoint
-  category     = "env"
+  key             = "VAULT_ADDR"
+  value           = data.terraform_remote_state.hcp_clusters.outputs.vault_public_endpoint
+  category        = "env"
   variable_set_id = tfe_variable_set.project_vault_auth.id
 }
 
 resource "tfe_variable" "vault_namespace" {
-  key          = "VAULT_NAMESPACE"
-  value        = "admin"
-  category     = "env"
+  key             = "VAULT_NAMESPACE"
+  value           = "admin"
+  category        = "env"
   variable_set_id = tfe_variable_set.project_vault_auth.id
 }
 
 resource "tfe_variable" "vault_auth_method" {
-  key          = "auth_method"
-  value        = "dynamic_creds"
-  category     = "terraform"
+  key             = "auth_method"
+  value           = "dynamic_creds"
+  category        = "terraform"
   variable_set_id = tfe_variable_set.project_vault_auth.id
 }
+

--- a/workload/main.tf
+++ b/workload/main.tf
@@ -170,9 +170,9 @@ resource "aws_lb_target_group" "frontend_tg" {
   vpc_id   = data.terraform_remote_state.networking.outputs.vpc_id
 }
 
-resource "aws_lb_target_group_attachment" "frontend_tg" {
-  target_group_arn = aws_lb_target_group.frontend_tg.arn
-  port             = 80
-  target_id        = data.terraform_remote_state.nomad_nodes.outputs.nomad_client_x86_asg
-}
+#resource "aws_lb_target_group_attachment" "frontend_tg" {
+#  target_group_arn = aws_lb_target_group.frontend_tg.arn
+#  port             = 80
+#  target_id        = data.terraform_remote_state.nomad_nodes.outputs.nomad_client_x86_asg
+#}
 

--- a/workload/main.tf
+++ b/workload/main.tf
@@ -5,23 +5,18 @@ terraform {
       version = "~> 0.0.6"
     }
 
-    aws = {
-      source  = "hashicorp/aws"
-      version = "~> 5.8.0"
-    }
-
     vault = {
-      source = "hashicorp/vault"
+      source  = "hashicorp/vault"
       version = "~> 3.18.0"
     }
 
     nomad = {
-      source = "hashicorp/nomad"
+      source  = "hashicorp/nomad"
       version = "2.0.0-beta.1"
     }
 
     consul = {
-      source = "hashicorp/consul"
+      source  = "hashicorp/consul"
       version = "2.18.0"
     }
   }
@@ -31,10 +26,10 @@ provider "doormat" {}
 
 provider "consul" {
   address = "${data.terraform_remote_state.hcp_clusters.outputs.consul_public_endpoint}:443"
-  token = data.terraform_remote_state.hcp_clusters.outputs.consul_root_token
-  scheme  = "https" 
+  token   = data.terraform_remote_state.hcp_clusters.outputs.consul_root_token
+  scheme  = "https"
 }
- 
+
 data "doormat_aws_credentials" "creds" {
   provider = doormat
   role_arn = "arn:aws:iam::${var.aws_account_id}:role/tfc-doormat-role_7_workload"
@@ -99,7 +94,7 @@ data "vault_kv_secret_v2" "bootstrap" {
 }
 
 provider "nomad" {
-  address = data.terraform_remote_state.nomad_cluster.outputs.nomad_public_endpoint
+  address   = data.terraform_remote_state.nomad_cluster.outputs.nomad_public_endpoint
   secret_id = data.vault_kv_secret_v2.bootstrap.data["SecretID"]
 }
 
@@ -116,8 +111,8 @@ resource "null_resource" "wait_for_db" {
 }
 
 data "consul_service" "mongo_service" {
-    depends_on = [ null_resource.wait_for_db ]
-    name = "demo-mongodb"
+  depends_on = [null_resource.wait_for_db]
+  name       = "demo-mongodb"
 }
 
 resource "vault_database_secrets_mount" "mongodb" {
@@ -168,20 +163,16 @@ resource "nomad_job" "frontend" {
   jobspec = file("${path.module}/nomad-jobs/frontend.hcl")
 }
 
-# resource "aws_lb_target_group" "frontend_tg" {
-#   name     = "frontend-tg"
-#   port     = 80
-#   protocol = "HTTP"
-#   vpc_id   = data.terraform_remote_state.networking.outputs.vpc_id
-# }
+resource "aws_lb_target_group" "frontend_tg" {
+  name     = "frontend-tg"
+  port     = 80
+  protocol = "HTTP"
+  vpc_id   = data.terraform_remote_state.networking.outputs.vpc_id
+}
 
-# resource "aws_lb_target_group_attachment" "frontend_tg" {
-#   target_group_arn = aws_lb_target_group.frontend_tg.arn
-#   port             = 80
-#   target_id        = data.terraform_remote_state.nomad_nodes.outputs.nomad_client_x86_asg
-# }
+resource "aws_lb_target_group_attachment" "frontend_tg" {
+  target_group_arn = aws_lb_target_group.frontend_tg.arn
+  port             = 80
+  target_id        = data.terraform_remote_state.nomad_nodes.outputs.nomad_client_x86_asg
+}
 
-# // Optional Full KVM based VM Example
-# resource "nomad_job" "fullvm" {
-#  jobspec = file("${path.module}/nomad-jobs/mongodb-vmdk.hcl")
-# }

--- a/workload/variables.tf
+++ b/workload/variables.tf
@@ -8,7 +8,7 @@ variable "stack_id" {
 }
 
 variable "tfc_organization" {
-  type    = string
+  type = string
 }
 
 variable "region" {


### PR DESCRIPTION
When building the demo for the first-time the variable set is unable to create with the error: 'no organization was specified on the resource or provider'

This change adds the 'organization' argument to the tfe_variable_set resource to correct this.